### PR TITLE
removed a critique setting as it had an old package name

### DIFF
--- a/src/NewTools-DocumentBrowser/ManifestNewToolsDocumentBrowser.class.st
+++ b/src/NewTools-DocumentBrowser/ManifestNewToolsDocumentBrowser.class.st
@@ -13,8 +13,3 @@ Class {
 	#superclass : #PackageManifest,
 	#category : #'NewTools-DocumentBrowser-Manifest'
 }
-
-{ #category : #'code-critics' }
-ManifestNewToolsDocumentBrowser class >> ruleBadMessageRule2V1FalsePositive [
-	^ #(#(#(#RGPackageDefinition #(#'Microdown-DocumentBrowser')) #'2022-07-13T10:42:18.082534+02:00') )
-]


### PR DESCRIPTION
A critique rule gave errors as it did not know of the refactoring.
This fixes that.