### PR TITLE
Remove references to SystemOrganizer

### DIFF
--- a/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
+++ b/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
@@ -63,33 +63,31 @@ MicPharoPackageCommentResourceReference >> categoryName [
 { #category : #private }
 MicPharoPackageCommentResourceReference >> childrenOfAllCategories [
 	"I return the children of 'comment://package/' "
-	^ (SystemOrganizer default categories 
-		reject: [ :cat | cat beginsWith: 'BaselineOf' ]
-		thenCollect: [:cat | self reduceCategoryName: cat]) 
-		asSet asArray sort
-			collect: [ :cat | ('comment://package/', cat) asMicResourceReference  ]
+
+	^ (Smalltalk organization categories
+		   reject: [ :cat | cat beginsWith: 'BaselineOf' ]
+		   thenCollect: [ :cat | self reduceCategoryName: cat ]) asSet asArray sort collect: [ :cat | ('comment://package/' , cat) asMicResourceReference ]
 ]
 
 { #category : #accessing }
 MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
 	"I am a prefix of a set of categories, 
 	my children are those categories with one more depth in their name"
+
 	| children |
 	categoryName ifEmpty: [ ^ self childrenOfAllCategories ].
-	children := SystemOrganizer default categories
-				select: [ :cat |  (cat beginsWith: categoryName) and: [ self isPackage: cat ] ]
-				thenCollect: [:cat | ('comment://package/', cat) asMicResourceReference ].
+	children := Smalltalk organization categories
+		            select: [ :cat | (cat beginsWith: categoryName) and: [ self isPackage: cat ] ]
+		            thenCollect: [ :cat | ('comment://package/' , cat) asMicResourceReference ].
 
 	^ children
-	
 ]
 
 { #category : #accessing }
 MicPharoPackageCommentResourceReference >> childrenOfPackageWithTag [
 	"my categoryName is a package tag, children are the classes under that tag"
-	^ (SystemOrganizer default classesInCategory:  categoryName)
-			collect: [:cl | ('comment://class/',cl name) asMicResourceReference]
-	 
+
+	^ (Smalltalk organization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
 ]
 
 { #category : #initialization }

--- a/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
+++ b/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
@@ -64,7 +64,7 @@ MicPharoPackageCommentResourceReference >> categoryName [
 MicPharoPackageCommentResourceReference >> childrenOfAllCategories [
 	"I return the children of 'comment://package/' "
 
-	^ (SystemOrganization categories
+	^ (Smalltalk organization categories
 		   reject: [ :cat | cat beginsWith: 'BaselineOf' ]
 		   thenCollect: [ :cat | self reduceCategoryName: cat ]) asSet asArray sort collect: [ :cat | ('comment://package/' , cat) asMicResourceReference ]
 ]
@@ -76,7 +76,7 @@ MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
 
 	| children |
 	categoryName ifEmpty: [ ^ self childrenOfAllCategories ].
-	children := SystemOrganization categories
+	children := Smalltalk organization categories
 		            select: [ :cat | (cat beginsWith: categoryName) and: [ self isPackage: cat ] ]
 		            thenCollect: [ :cat | ('comment://package/' , cat) asMicResourceReference ].
 
@@ -87,7 +87,7 @@ MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
 MicPharoPackageCommentResourceReference >> childrenOfPackageWithTag [
 	"my categoryName is a package tag, children are the classes under that tag"
 
-	^ (SystemOrganization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
+	^ (Smalltalk organization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
 ]
 
 { #category : #initialization }

--- a/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
+++ b/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
@@ -64,7 +64,7 @@ MicPharoPackageCommentResourceReference >> categoryName [
 MicPharoPackageCommentResourceReference >> childrenOfAllCategories [
 	"I return the children of 'comment://package/' "
 
-	^ (Smalltalk organization categories
+	^ (SystemOrganization categories
 		   reject: [ :cat | cat beginsWith: 'BaselineOf' ]
 		   thenCollect: [ :cat | self reduceCategoryName: cat ]) asSet asArray sort collect: [ :cat | ('comment://package/' , cat) asMicResourceReference ]
 ]
@@ -76,7 +76,7 @@ MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
 
 	| children |
 	categoryName ifEmpty: [ ^ self childrenOfAllCategories ].
-	children := Smalltalk organization categories
+	children := SystemOrganization categories
 		            select: [ :cat | (cat beginsWith: categoryName) and: [ self isPackage: cat ] ]
 		            thenCollect: [ :cat | ('comment://package/' , cat) asMicResourceReference ].
 
@@ -87,7 +87,7 @@ MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
 MicPharoPackageCommentResourceReference >> childrenOfPackageWithTag [
 	"my categoryName is a package tag, children are the classes under that tag"
 
-	^ (Smalltalk organization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
+	^ (SystemOrganization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
 ]
 
 { #category : #initialization }


### PR DESCRIPTION
SysytemOrganizer will probably be removed in Pharo 12. Instead, RPackageOrganizer will have the responsibility the SystemOrganizer currently has.  In order to plan the change I propose to remove the reperences to it and use `Smalltalk organization` as entry point.