### PR TITLE
Depend on tagged version of Iceberg

### DIFF
--- a/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
+++ b/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
@@ -18,7 +18,7 @@ BaselineOfNewToolsDocumentBrowser >> baseline: spec [
 
 		spec
 			baseline: 'Iceberg'
-			with: [ spec repository: 'github://pharo-vcs/Iceberg:dev-2.0' ].
+			with: [ spec repository: 'github://pharo-vcs/Iceberg:v2.1.1' ].
 
 		spec
 			package: #'Microdown-RichTextPresenter'


### PR DESCRIPTION
In Pharo 11 we should depend on the tagged version of Iceberg else Pharo build is breaking