### PR TITLE
Improve tests that are failing on other CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,26 +4,22 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PHARO_CI_TESTING_ENVIRONMENT: 1
 
-on:
-  push:
-  pull_request:
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+on: [ push, pull_request ]
 
 jobs:
   build:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        smalltalk: [ Pharo64-11 ]
+        smalltalk: [ Pharo64-12 ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup smalltalkCI
         uses: hpi-swa/setup-smalltalkCI@v1
         with:
-          smalltalk-version: ${{ matrix.smalltalk }}
+          smalltalk-image: ${{ matrix.smalltalk }}
       - name: Load Image and Run Tests
         run: smalltalkci -s ${{ matrix.smalltalk }}
         timeout-minutes: 15

--- a/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
+++ b/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
@@ -13,7 +13,7 @@ BaselineOfNewToolsDocumentBrowser >> baseline: spec [
 			baseline: 'Microdown'
 			with: [
 				spec
-					repository: 'github://pillar-markup/Microdown:integration/src';
+					repository: 'github://pillar-markup/Microdown:Pharo12/src';
 					loads: #('RichText') ].
 
 		spec

--- a/src/NewTools-DocumentBrowser-Tests/MicPharoPackageCommentResourceReferenceTest.class.st
+++ b/src/NewTools-DocumentBrowser-Tests/MicPharoPackageCommentResourceReferenceTest.class.st
@@ -86,13 +86,14 @@ MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory [
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_emptyPrefix [
+
 	| dir prefixes |
 	dir := 'comment://package/' asMicResourceReference loadChildren.
 	self assert: (dir size between: 100 and: 200).
 	"check that four known prefises are in the found set."
-	prefixes := dir collect: [ :ref | ref uri segments first ].
-	self assert: (#(AST Collections Refactoring Iceberg) \ prefixes) isEmpty.
-	self assert: (prefixes allSatisfy: [:prefix | (prefix occurrencesOf: $-) = 0])
+	prefixes := dir collect: [ :ref | ref categoryName ].
+	self assertEmpty: #( AST Collections Refactoring Iceberg ) \ prefixes.
+	self assert: (prefixes noneSatisfy: [ :prefix | prefix includes: $- ])
 ]
 
 { #category : #tests }
@@ -111,10 +112,13 @@ MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_package [
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_prefix [
-	| ref dir |
-	ref := 'comment://package/NewTools-DocumentBrowser' asMicResourceReference.
-	dir := ref loadChildren.
-	self assert: dir size equals: 4
+
+	| dir |
+	dir := 'comment://package/NewTools-DocumentBrowser' asMicResourceReference loadChildren.
+	self
+		assertCollection: (dir collect: [ :ref | ref categoryName ])
+		hasSameElements:
+		#( 'NewTools-DocumentBrowser-BlockModel' 'NewTools-DocumentBrowser-Deprecated' 'NewTools-DocumentBrowser-GUI' 'NewTools-DocumentBrowser-ResourceModel' )
 ]
 
 { #category : #tests }


### PR DESCRIPTION
This change improves some tests that are failing on Spec and NewTools CI.  It makes them less flaky and will give more feedback in case they are failing.

This also make P12 branch points P12 dependency and updates the CI to build against P12.