### PR TITLE
Remove concept of categories from MicPharoPackageCommentResourceRefer…

### DIFF
--- a/src/NewTools-DocumentBrowser-Tests/MicPharoPackageCommentResourceReferenceTest.class.st
+++ b/src/NewTools-DocumentBrowser-Tests/MicPharoPackageCommentResourceReferenceTest.class.st
@@ -20,14 +20,6 @@ MicPharoPackageCommentResourceReferenceTest >> tearDown [
 ]
 
 { #category : #tests }
-MicPharoPackageCommentResourceReferenceTest >> testCategoryName [
-	| ref |
-	ref := 'comment://package/Microdown' asMicResourceReference.
-	self assert: ref categoryName equals: 'Microdown'.
-	
-]
-
-{ #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testContents [
 	| ref |
 	ref := 'comment://package/Microdown' asMicResourceReference.
@@ -48,30 +40,20 @@ MicPharoPackageCommentResourceReferenceTest >> testIsPackage [
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testIsTag [
-	self deny: 'comment://package/Microdown' asMicResourceReference isTag .
-	self 
-		assert: 'comment://package/Microdown-Core' asMicResourceReference isTag .
-	self 
-		assert: 'comment://package/Microdown-RichTextComposer-Table-Support' asMicResourceReference isTag.
-	self
-		deny: 'comment://package/Calypso-SystemPlugins-ClassScripts' asMicResourceReference isTag
+
+	self deny: 'comment://package/Microdown' asMicResourceReference isTag.
+	self assert: 'comment://package/Microdown?tag=Core' asMicResourceReference isTag.
+	self assert: 'comment://package/Microdown-RichTextComposer?tag=Table-Support' asMicResourceReference isTag.
+	self deny: 'comment://package/Calypso-SystemPlugins-ClassScripts' asMicResourceReference isTag
 ]
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testKind [
-	self 
-		assert: 'comment://package/Microdown*' asMicResourceReference kind 
-		equals: #prefix.
-	self 
-		assert: 'comment://package/Microdown' asMicResourceReference kind 
-		equals: #package.
-	self 
-		assert: 'comment://package/Microdown-Core' asMicResourceReference kind 
-		equals: #tag.
-	self 
-		assert: 'comment://package/Microdown-RichTextComposer-Table-Support' asMicResourceReference kind 
-		equals: #tag.
-	
+
+	self assert: 'comment://package/Microdown*' asMicResourceReference kind equals: #prefix.
+	self assert: 'comment://package/Microdown' asMicResourceReference kind equals: #package.
+	self assert: 'comment://package/Microdown?tag=Core' asMicResourceReference kind equals: #tag.
+	self assert: 'comment://package/Microdown-RichTextComposer?tag=Table-Support' asMicResourceReference kind equals: #tag
 ]
 
 { #category : #tests }
@@ -91,23 +73,22 @@ MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_emptyPrefix [
 	dir := 'comment://package/' asMicResourceReference loadChildren.
 	self assert: (dir size between: 100 and: 200).
 	"check that four known prefises are in the found set."
-	prefixes := dir collect: [ :ref | ref categoryName ].
+	prefixes := dir collect: [ :ref | ref packageName ].
 	self assertEmpty: #( AST Collections Refactoring Iceberg ) \ prefixes.
 	self assert: (prefixes noneSatisfy: [ :prefix | prefix includes: $- ])
 ]
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_package [
+
 	| ref dir |
 	ref := 'comment://package/Microdown?kind=package' asMicResourceReference.
 	dir := ref loadChildren.
 	"Expect Extension and Manifest tags removed"
-	self assert: dir size equals: ('Microdown' asPackage classTags size - 2).
-	self assert: (dir allSatisfy: [ :r |r class = MicPharoPackageCommentResourceReference  ] ).
-	self assert: (dir first uri segments first beginsWith: 'Microdown-').
-	self assert: (dir allSatisfy: [:r | r kind = #tag])
-	
-	
+	self assert: dir size equals: 'Microdown' asPackage classTags size - 2.
+	self assert: (dir allSatisfy: [ :r | r class = MicPharoPackageCommentResourceReference ]).
+	self assert: (dir allSatisfy: [ :r | r packageName = 'Microdown' ]).
+	self assert: (dir allSatisfy: [ :r | r kind = #tag ])
 ]
 
 { #category : #tests }
@@ -115,20 +96,20 @@ MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_prefix [
 
 	| dir |
 	dir := 'comment://package/NewTools-DocumentBrowser' asMicResourceReference loadChildren.
-	self
-		assertCollection: (dir collect: [ :ref | ref categoryName ])
-		hasSameElements:
-		#( 'NewTools-DocumentBrowser-BlockModel' 'NewTools-DocumentBrowser-Deprecated' 'NewTools-DocumentBrowser-GUI' 'NewTools-DocumentBrowser-ResourceModel' )
+
+	self assert: (dir allSatisfy: [ :r | r packageName = 'NewTools-DocumentBrowser' ]).
+	self assertCollection: (dir collect: [ :ref | ref tagName ]) hasSameElements: #( 'BlockModel' 'Deprecated' 'GUI' 'ResourceModel' )
 ]
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testLoadDirectory_withTag [
+
 	| ref dir |
-	ref := 'comment://package/NewTools-DocumentBrowser-Tests-ResourceModel' asMicResourceReference.
+	ref := 'comment://package/NewTools-DocumentBrowser-Tests?tag=ResourceModel' asMicResourceReference.
 	dir := ref loadChildren.
 	self assert: dir notEmpty.
-	self assert: (dir allSatisfy: [ :r |r class = MicPharoClassCommentResourceReference  ] ).
-	self assert: (dir anySatisfy:  [:aRef | aRef uri segments first = self class name])
+	self assert: (dir allSatisfy: [ :r | r class = MicPharoClassCommentResourceReference ]).
+	self assert: (dir anySatisfy: [ :aRef | aRef uri segments first = self class name ])
 ]
 
 { #category : #tests }
@@ -155,35 +136,37 @@ MicPharoPackageCommentResourceReferenceTest >> testPackageComment_NotThere [
 ]
 
 { #category : #tests }
-MicPharoPackageCommentResourceReferenceTest >> testParentPackage [
-	self 
-		assert: 'comment://package/Microdown' asMicResourceReference parentPackage 
-		equals: 'Microdown' asPackage.
-	self 
-		assert: 'comment://package/Microdown-Core' asMicResourceReference parentPackage 
-		equals: 'Microdown' asPackage.
-	self 
-		assert: 'comment://package/Microdown-RichTextComposer-Table-Support' asMicResourceReference parentPackage 
-		equals: 'Microdown-RichTextComposer' asPackage.
-	self
-		assert: 'comment://package/Calypso-SystemPlugins-ClassScripts' asMicResourceReference parentPackage
-		equals: nil
+MicPharoPackageCommentResourceReferenceTest >> testPackageName [
+
+	| ref |
+	ref := 'comment://package/Microdown' asMicResourceReference.
+	self assert: ref packageName equals: 'Microdown'
 ]
 
 { #category : #tests }
-MicPharoPackageCommentResourceReferenceTest >> testReduceCategoryNameToLevel [
+MicPharoPackageCommentResourceReferenceTest >> testPackageNameWithTag [
+
+	| ref |
+	ref := 'comment://package/Microdown?tag=Core' asMicResourceReference.
+	self assert: ref packageName equals: 'Microdown'.
+	self assert: ref tagName equals: 'Core'
+]
+
+{ #category : #tests }
+MicPharoPackageCommentResourceReferenceTest >> testReducePackageNameToLevel [
 	 | dummy |
 	dummy := MicPharoPackageCommentResourceReference new.
-	self assert: (dummy reduceCategoryName: '' toLevel: -1) equals: ''.
-	self assert: (dummy reduceCategoryName: 'aaa-bbb-ccc' toLevel: 0) equals: 'aaa'.
-	self assert: (dummy reduceCategoryName: 'aaa-bbb-ccc' toLevel: 1) equals: 'aaa-bbb'.
-	self assert: (dummy reduceCategoryName: 'aaa-bbb-ccc' toLevel: 2) equals: 'aaa-bbb-ccc'
+	self assert: (dummy reducePackageName: '' toLevel: -1) equals: ''.
+	self assert: (dummy reducePackageName: 'aaa-bbb-ccc' toLevel: 0) equals: 'aaa'.
+	self assert: (dummy reducePackageName: 'aaa-bbb-ccc' toLevel: 1) equals: 'aaa-bbb'.
+	self assert: (dummy reducePackageName: 'aaa-bbb-ccc' toLevel: 2) equals: 'aaa-bbb-ccc'
 ]
 
 { #category : #tests }
 MicPharoPackageCommentResourceReferenceTest >> testSetup [
+
 	| ref |
 	ref := 'comment://package/Microdown' asMicResourceReference.
 	self assert: ref class equals: MicPharoPackageCommentResourceReference.
-	self assert: ref categoryName equals: 'Microdown'
+	self assert: ref packageName equals: 'Microdown'
 ]

--- a/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
+++ b/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
@@ -68,7 +68,7 @@ MicPharoPackageCommentResourceReference >> childrenOfAllPackages [
 
 	^ (self packageOrganizer packageNames
 		   reject: [ :package | package beginsWith: 'BaselineOf' ]
-		   thenCollect: [ :package | self reducePackgeName: package ]) asSet asArray sort collect: [ :package |
+		   thenCollect: [ :package | self reducePackageName: package ]) asSet asArray sort collect: [ :package |
 		  ('comment://package/' , package) asMicResourceReference ]
 ]
 
@@ -97,7 +97,7 @@ MicPharoPackageCommentResourceReference >> childrenOfPackageWithTag [
 	"In case I matche a package tag, children are the classes under that tag"
 
 	^ ((self packageOrganizer packageNamed: self packageName ifAbsent: [ ^ #(  ) ])
-		classTagNamed: self tagName ifAbsent: [ #(  ) ]) classes
+		classTagNamed: self tagName ifAbsent: [ ^ #(  ) ]) classes
 			collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
 ]
 
@@ -186,7 +186,7 @@ MicPharoPackageCommentResourceReference >> reducePackageName: aString toLevel: l
 ]
 
 { #category : #'private - utilities' }
-MicPharoPackageCommentResourceReference >> reducePackgeName: aPackageName [
+MicPharoPackageCommentResourceReference >> reducePackageName: aPackageName [
 
 	^ self reducePackageName: aPackageName toLevel: self level + 1
 ]

--- a/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
+++ b/src/NewTools-DocumentBrowser/MicPharoPackageCommentResourceReference.class.st
@@ -1,26 +1,32 @@
 "
 My prime purpose it to allow access to the package comment.
 
-My uri syntax is: `comment://package/categoryName`.
+My uri syntax is: `comment://package/{packageName}`.
+
+We can also create an URI to a package tag with this syntax: `comment://package/{packageName}?tag={tagName}`.
 
 ## loadMicrodown
-My `loadMicrodown` returns the package comment of the package named categoryName or empty text if categoryName is not a package or if the package has no comment. Notice, `loadMicrodown` will return the synthesized comment (created by the class side method `buildMicroDownUsing:withComment:`)
 
-When categoryName is a package, my two methods `contents` and `contents:` reads and writes the contents of the package comment.
+My `loadMicrodown` returns the package comment of the package named packageName or empty text if packageName is not a package or if the package has no comment. Notice, `loadMicrodown` will return the synthesized comment (created by the class side method `buildMicroDownUsing:withComment:`)
+
+When packageName is a package, my two methods `contents` and `contents:` reads and writes the contents of the package comment.
 
 ## loadDirectory
+
 My 'loadDirectory' has been designed to provide a deep directory. 
 
-Most class category names are of the form 'aaa-bbb-ccc-ddd'. A call to `loadDirectory` with categoryName being 'aaa' will give children 'aaa-xxx','aaa-yyy','aaa-zzz'. A call with 'aaa-bbb' will return children 'aaa-bbb-xxx', 'aaa-bbb-yyy' etc.
+Most class package names are of the form 'aaa-bbb-ccc-ddd'. A call to `loadDirectory` with categoryName being 'aaa' will give children 'aaa-xxx','aaa-yyy','aaa-zzz'. A call with 'aaa-bbb' will return children 'aaa-bbb-xxx', 'aaa-bbb-yyy' etc.
 
 ### Details
-In `comment://package/categoryName`, categoryName can be one of three cases:
+
+In `comment://package/packageName`, packageName can be one of two cases:
 * A package name, with children being the tags or classes if the package has no tags
-* A tag of the form 'PackageName-tag', with children being the classes of the tag
 * A package name prefix of the form 'AI-Algorithms' wich is neither a package or a tag in a package, with children being those categories of which 'AI-Algorithms' is a prefix.
 
 A special case is somewhat common, for example 'Microdown' is both a package name and a prefix for other packages.
 In this case, the prefix 'Microdown' takes precedence  over package, and `comment://package/Microdown` has as children those categories prefixed my 'Microdown' _and_ the Microdown package.
+
+In case the URI point a tag, the children are the classes in the tag.
 
 "
 Class {
@@ -28,7 +34,8 @@ Class {
 	#superclass : #MicPharoCommentResourceReference,
 	#instVars : [
 		'kind',
-		'categoryName'
+		'packageName',
+		'tagName'
 	],
 	#category : #'NewTools-DocumentBrowser-ResourceModel'
 }
@@ -43,101 +50,85 @@ MicPharoPackageCommentResourceReference >> browserIcon [
 
 { #category : #'document browser' }
 MicPharoPackageCommentResourceReference >> browserTitle [
-	kind = 'prefix'
-		ifTrue: [ ^categoryName ,'*' ].
-	^ categoryName 
+
+	kind = 'prefix' ifTrue: [ ^ self packageName , '*' ].
+	^ self packageName
 ]
 
 { #category : #testing }
 MicPharoPackageCommentResourceReference >> canSave [
 	"return true if I implement contents: "
-	^self isPackage
-]
 
-{ #category : #accessing }
-MicPharoPackageCommentResourceReference >> categoryName [
-
-	^ categoryName
+	^ self isPackage
 ]
 
 { #category : #private }
-MicPharoPackageCommentResourceReference >> childrenOfAllCategories [
+MicPharoPackageCommentResourceReference >> childrenOfAllPackages [
 	"I return the children of 'comment://package/' "
 
-	^ (Smalltalk organization categories
-		   reject: [ :cat | cat beginsWith: 'BaselineOf' ]
-		   thenCollect: [ :cat | self reduceCategoryName: cat ]) asSet asArray sort collect: [ :cat | ('comment://package/' , cat) asMicResourceReference ]
+	^ (self packageOrganizer packageNames
+		   reject: [ :package | package beginsWith: 'BaselineOf' ]
+		   thenCollect: [ :package | self reducePackgeName: package ]) asSet asArray sort collect: [ :package |
+		  ('comment://package/' , package) asMicResourceReference ]
+]
+
+{ #category : #initialization }
+MicPharoPackageCommentResourceReference >> childrenOfPackage [
+	"I assume I am a package, return my tags"
+
+	| tags |
+	tags := self package classTags reject: [ :tag | #( Manifest Extensions ) includes: tag name ].
+	^ (tags asArray sorted: #name ascending) collect: [ :tag | ('comment://package/' , self packageName , '?tag=' , tag name) asMicResourceReference ]
 ]
 
 { #category : #accessing }
-MicPharoPackageCommentResourceReference >> childrenOfCategoryPrefix [
-	"I am a prefix of a set of categories, 
-	my children are those categories with one more depth in their name"
+MicPharoPackageCommentResourceReference >> childrenOfPackagePrefix [
+	"I am a prefix of a set of packages, 
+	my children are those packages with one more depth in their name"
 
-	| children |
-	categoryName ifEmpty: [ ^ self childrenOfAllCategories ].
-	children := Smalltalk organization categories
-		            select: [ :cat | (cat beginsWith: categoryName) and: [ self isPackage: cat ] ]
-		            thenCollect: [ :cat | ('comment://package/' , cat) asMicResourceReference ].
-
-	^ children
+	self packageName ifEmpty: [ ^ self childrenOfAllPackages ].
+	^ self packageOrganizer packageName
+		  select: [ :package | package beginsWith: self packageName ]
+		  thenCollect: [ :package | ('comment://package/' , package) asMicResourceReference ]
 ]
 
 { #category : #accessing }
 MicPharoPackageCommentResourceReference >> childrenOfPackageWithTag [
-	"my categoryName is a package tag, children are the classes under that tag"
+	"In case I matche a package tag, children are the classes under that tag"
 
-	^ (Smalltalk organization classesInCategory: categoryName) collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
-]
-
-{ #category : #initialization }
-MicPharoPackageCommentResourceReference >> childrenOfRPackage [
-	"I assume I am a RPackage, return my tags"
-	|tags| 
-	tags := (categoryName asPackage classTags) 
-			reject: [:tag | #(Manifest Extensions) includes: tag name].
-	tags := tags asArray sort: [ :a :b | a name < b name ].
-	^ tags collect: [ :tag |
-		('comment://package/', ( categoryName, '-', tag name )) asMicResourceReference  ]
+	^ ((self packageOrganizer packageNamed: self packageName ifAbsent: [ ^ #(  ) ])
+		classTagNamed: self tagName ifAbsent: [ #(  ) ]) classes
+			collect: [ :class | ('comment://class/' , class name) asMicResourceReference ]
 ]
 
 { #category : #accessing }
-MicPharoPackageCommentResourceReference >> contents [ 
-	[ ^ categoryName asPackage packageComment ]
-	on: NotFound 
-	do: [ ^ '' ]
+MicPharoPackageCommentResourceReference >> contents [
+
+	[ ^ self package packageComment ]
+		on: NotFound
+		do: [ ^ '' ]
 ]
 
 { #category : #accessing }
-MicPharoPackageCommentResourceReference >> contents: aNewComment [ 
-	[ ^ categoryName asPackage packageComment: aNewComment]
-	on: NotFound 
-	do: [ MicResourceReferenceError signal: 'No package named ', categoryName]
+MicPharoPackageCommentResourceReference >> contents: aNewComment [
+
+	[ ^ self package packageComment: aNewComment ]
+		on: NotFound
+		do: [ MicResourceReferenceError signal: 'No package named ' , self packageName ]
 ]
 
 { #category : #testing }
 MicPharoPackageCommentResourceReference >> isPackage [
-	categoryName asPackageIfAbsent: [ ^ false ].
-	^true
-]
 
-{ #category : #'private - utilities' }
-MicPharoPackageCommentResourceReference >> isPackage: cat [
-	cat asPackageIfAbsent: [ ^ false ].
-	^true
+	self packageName asPackageIfAbsent: [ ^ false ].
+	^ true
 ]
 
 { #category : #testing }
 MicPharoPackageCommentResourceReference >> isTag [
 	"return true if I am tag inside a package"
-	| parent |
-	parent := self parentPackage.
-	"if no parent package exist, I am not a tag"
-	parent ifNil: [ ^ false ].
-	"If I am my own parent, I am not a tag"
-	parent name = categoryName ifTrue: [ ^ false ].
-	"I have a parent package, so I am a tag"
-	^ true
+
+	^ self kind = #tag
 ]
 
 { #category : #accessing }
@@ -148,15 +139,16 @@ MicPharoPackageCommentResourceReference >> kind [
 
 { #category : #'private - utilities' }
 MicPharoPackageCommentResourceReference >> level [
-	"return the number of '-' in categoryName"
-	categoryName ifEmpty: [ ^-1 ].
-	^ categoryName occurrencesOf: $-
+	"return the number of '-' in package name"
+
+	self packageName ifEmpty: [ ^ -1 ].
+	^ self packageName occurrencesOf: $-
 ]
 
 { #category : #accessing }
 MicPharoPackageCommentResourceReference >> loadChildren [
-	kind = #prefix ifTrue: [ ^ self childrenOfCategoryPrefix  ].
-	kind = #package ifTrue: [ ^ self childrenOfRPackage  ].
+	kind = #prefix ifTrue: [ ^ self childrenOfPackagePrefix  ].
+	kind = #package ifTrue: [ ^ self childrenOfPackage  ].
 	kind = #tag ifTrue: [ ^ self childrenOfPackageWithTag  ].
 	MicResourceReferenceError signal: 'Unknow kind in ', self uri printString.
 ]
@@ -164,53 +156,63 @@ MicPharoPackageCommentResourceReference >> loadChildren [
 { #category : #loading }
 MicPharoPackageCommentResourceReference >> loadMicrodown [
 	"I override to provide the comment produced by beautifulComments"
+
 	| builder |
 	self isPackage ifFalse: [ ^ Microdown parse: 'No documentation for tags or package prefixes' ].
 	builder := Microdown builder.
-	self categoryName asPackage  
-		buildMicroDownUsing: builder 
-		withComment: self contents.
+	self package buildMicroDownUsing: builder withComment: self contents.
 	^ Microdown parse: builder contents
 ]
 
-{ #category : #testing }
-MicPharoPackageCommentResourceReference >> parentPackage [
-	"return my parent package, or nil if none exist"
-	| parts package |
-	parts := categoryName splitOn: '-'.
-	parts size to: 1 by: -1 do: [ :i | 
-		package := ((parts first: i) joinUsing: '-') asPackageIfAbsent: [ nil ].
-		package ifNotNil: [ ^ package ]
-		 ].
-	^ nil
+{ #category : #accessing }
+MicPharoPackageCommentResourceReference >> package [
+
+	^ self packageName asPackage
+]
+
+{ #category : #accessing }
+MicPharoPackageCommentResourceReference >> packageName [
+
+	^ packageName
 ]
 
 { #category : #'private - utilities' }
-MicPharoPackageCommentResourceReference >> reduceCategoryName: aCategory [
-	^ self reduceCategoryName: aCategory toLevel: self level + 1
-]
-
-{ #category : #'private - utilities' }
-MicPharoPackageCommentResourceReference >> reduceCategoryName: aString toLevel: level [ 
+MicPharoPackageCommentResourceReference >> reducePackageName: aString toLevel: level [
 	"a package name aaa-bbb-ccc-ddd reduced to level 0 is aaa, reduced to 2 is aaa-bbb-ccc"
+
 	| parts |
 	parts := aString splitOn: $-.
-	^ (parts first: level+1) joinUsing: $-
+	^ (parts first: level + 1) joinUsing: $-
+]
+
+{ #category : #'private - utilities' }
+MicPharoPackageCommentResourceReference >> reducePackgeName: aPackageName [
+
+	^ self reducePackageName: aPackageName toLevel: self level + 1
+]
+
+{ #category : #accessing }
+MicPharoPackageCommentResourceReference >> tagName [
+	^ tagName
 ]
 
 { #category : #accessing }
 MicPharoPackageCommentResourceReference >> uri: aUri [
 	"the uri is on the form commet://package/packageName - 
 	packageName can be a prefix of a full package name"
+
 	super uri: aUri.
-	categoryName := aUri segments
-		ifNil: ['*']
-		ifNotNil: [ :segments | segments first ].
-	kind := (categoryName endsWith: '*') 
-		ifTrue: [ categoryName := categoryName withoutSuffix: '*'. 'prefix' ]
-		ifFalse: [ 
-			self isPackage 
-				ifTrue:['package']
-				ifFalse: [ 'tag' ]
-			]
+	packageName := aUri segments
+		               ifNil: [ '*' ]
+		               ifNotNil: [ :segments | segments first ].
+	kind := (packageName endsWith: '*')
+		        ifTrue: [
+			        packageName := packageName withoutSuffix: '*'.
+			        #prefix ]
+		        ifFalse: [
+			        aUri queryAt: #tag ifPresent: [ :value | tagName := value ].
+
+			        self tagName
+				        ifNil: [ #package ]
+				        ifNotNil: [ #tag ] ]
 ]


### PR DESCRIPTION
…ence

MicPharoPackageCommentResourceReference manipulates categories that are a mix of packages and tags. But this causes problems because with the URI `'comment://package/Microdown-RichTextComposer-Table-Support'` we cannot know exactly what is our target since it could be:
- Package `Microdown` tag `RichTextComposer-Table-Support`
- Package `Microdown-RichTextComposer` tag `Table-Support`
- Package `Microdown-RichTextComposer-Table` tag `Support`
- Package `Microdown-RichTextComposer-Table-Support` without tag

So I propose this alternitvie syntax: `'comment://package/Microdown-RichTextComposer?tag=Table-Support'`

I also remove all usage of the categories API from the document browser and references to Smalltalk