### PR TITLE
Make BaselineOfNewToolsDocumentBrowser for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘integration’ for Microdown

### DIFF
--- a/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
+++ b/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
@@ -13,7 +13,7 @@ BaselineOfNewToolsDocumentBrowser >> baseline: spec [
 			baseline: 'Microdown'
 			with: [
 				spec
-					repository: 'github://pillar-markup/Microdown:integration/src';
+					repository: 'github://pillar-markup/Microdown:v2.4.1/src';
 					loads: #('RichText') ].
 
 		spec


### PR DESCRIPTION
This pull request makes BaselineOfNewToolsDocumentBrowser for Pharo 11 use the tag ‘v2.4.1’ instead of the branch ‘integration’ for Microdown, see [Pharo issue #17391](https://github.com/pharo-project/pharo/issues/17391).