### PR TITLE
Update version of Iceberg in BaselineOfNewToolsDocumentBrowser for Pharo 11 to ‘v2.2.3’

### DIFF
--- a/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
+++ b/src/BaselineOfNewToolsDocumentBrowser/BaselineOfNewToolsDocumentBrowser.class.st
@@ -18,7 +18,7 @@ BaselineOfNewToolsDocumentBrowser >> baseline: spec [
 
 		spec
 			baseline: 'Iceberg'
-			with: [ spec repository: 'github://pharo-vcs/Iceberg:v2.2.2' ].
+			with: [ spec repository: 'github://pharo-vcs/Iceberg:v2.2.3' ].
 
 		spec
 			package: #'Microdown-RichTextPresenter'


### PR DESCRIPTION
This pull request updates the version of Iceberg in BaselineOfNewToolsDocumentBrowser for Pharo 11 to ‘v2.2.3’ (it was updated in BaselineOfPharo in [Pharo pull request #17644](https://github.com/pharo-project/pharo/pull/17644)).