### PR TITLE
Move extensions to package

### DIFF
--- a/src/NewTools-DocumentBrowser/MicAbstractBlock.extension.st
+++ b/src/NewTools-DocumentBrowser/MicAbstractBlock.extension.st
@@ -14,11 +14,6 @@ Select the whole document for editing'
 ]
 
 { #category : '*NewTools-DocumentBrowser' }
-MicAbstractBlock >> isHeader [
-	^ false
-]
-
-{ #category : '*NewTools-DocumentBrowser' }
 MicAbstractBlock >> loadMicrodown [
 	"polymorphic with resource references"
 	^ self

--- a/src/NewTools-DocumentBrowser/MicHeaderBlock.extension.st
+++ b/src/NewTools-DocumentBrowser/MicHeaderBlock.extension.st
@@ -1,6 +1,0 @@
-Extension { #name : 'MicHeaderBlock' }
-
-{ #category : '*NewTools-DocumentBrowser' }
-MicHeaderBlock >> isHeader [
-	^ true
-]


### PR DESCRIPTION
Move extensions to proper places:
 - to the defining classes if possible
 - to the user if (and very clear) there is only one
 - close to other similar extensions if possible

Related to https://github.com/pharo-project/pharo/pull/19150