### PR TITLE
ignoreNotImplementedSelectors: in newtools

### DIFF
--- a/src/Microdown-RichTextPresenter-Tests/MicrodownSpecComponentForTest.class.st
+++ b/src/Microdown-RichTextPresenter-Tests/MicrodownSpecComponentForTest.class.st
@@ -24,6 +24,7 @@ MicrodownSpecComponentForTest class >> defaultLayout [
 { #category : 'specs' }
 MicrodownSpecComponentForTest class >> open [
 	<script>
+	<ignoreNotImplementedSelectors: #( openWithSpec )>
 	self new openWithSpec
 ]
 


### PR DESCRIPTION
Is the open method broken?